### PR TITLE
add : express-async-errors 추가 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.16.4",
+    "express-async-errors": "^3.1.1",
     "global": "^4.4.0",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^4.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,6 +2117,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+express-async-errors@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
+  integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==
+
 express@^4.16.2, express@^4.16.4:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"


### PR DESCRIPTION
import 'express-async-errors'

프로미스 반환 비동기함수 마지막 미들웨어로 에러 처리 가능해짐.